### PR TITLE
Add --verbose

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14, 16, 18]
+        node-version: [16, 18]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ Requirement:
 ## Usage
 
     Usage
-      $ npx find-node-modules-import [file|glob*]
+      $ find-node-modules-import [file|glob*]
  
     Options
-      --module          [String] filter the result by module name
+      --module              [String] filter the result by module name
       --builtinModules      [Boolean] filter the result by Node.js builtin modules. Default: false
+      --verbose             [Boolean] show warning/error output. Default: false
 
     Examples
       # show all imports
@@ -36,6 +37,8 @@ Requirement:
       $ find-node-modules-import "src/**/*.{js, ts}" --builtinModules
       # show specific module
       $ find-node-modules-import "src/**/*.{js, ts}" --module "lodash"
+
+
 
 ## Changelog
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,8 +14,9 @@ export const cli = meow(
       $ find-node-modules-import [file|glob*]
  
     Options
-      --module          [String] filter the result by module name
+      --module              [String] filter the result by module name
       --builtinModules      [Boolean] filter the result by Node.js builtin modules. Default: false
+      --verbose             [Boolean] show warning/error output. Default: false
 
     Examples
       # show all imports
@@ -73,7 +74,7 @@ export const run = async (
             });
         } catch (e) {
             if (flags.verbose) {
-                console.warn("Skip file", file, e);
+                console.error("Skip file", file, e);
             }
         }
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,10 @@ export const cli = meow(
             format: {
                 type: "string",
                 default: "compat"
+            },
+            verbose: {
+                type: "boolean",
+                default: false
             }
         },
         autoHelp: true,
@@ -68,7 +72,9 @@ export const run = async (
                 console.log(`${file}:${result.loc.start.line}:${result.loc.start.column}\t${result.name}`);
             });
         } catch (e) {
-            console.warn("Skip file", file, e);
+            if (flags.verbose) {
+                console.warn("Skip file", file, e);
+            }
         }
     }
     return { exitStatus: 0, stdout: null, stderr: null };

--- a/test/findNodeModulesImport.test.ts
+++ b/test/findNodeModulesImport.test.ts
@@ -1,6 +1,5 @@
-import { findNodeModulesImport } from "../src/find-node-modules-import.js";
+import { findNodeModulesImport, filterModulesByBuiltinModules } from "../src/find-node-modules-import.js";
 import assert from "node:assert";
-import { filterModulesByBuiltinModules } from "../lib/find-node-modules-import.js";
 
 describe("findNodeModulesImport", function () {
     it("filterModulesByBuiltinModules filter only builtin modules", async function () {


### PR DESCRIPTION

    Usage
      $ find-node-modules-import [file|glob*]
 
    Options
      --module              [String] filter the result by module name
      --builtinModules      [Boolean] filter the result by Node.js builtin modules. Default: false
      --verbose             [Boolean] show warning/error output. Default: false

    Examples
      # show all imports
      $ find-node-modules-import "src/**/*.{js, ts}"
      # show Node.js builtin modules
      $ find-node-modules-import "src/**/*.{js, ts}" --builtinModules
      # show specific module
      $ find-node-modules-import "src/**/*.{js, ts}" --module "lodash"

