### PR TITLE
refactor: use git clean instead of rimraf

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,5 @@ jobs:
         run: yarn install
       - name: Test
         run: yarn test
+      - name: Clean Test
+        run: yarn run clean

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,11 +4,13 @@ permissions:
   contents: read
 jobs:
   test:
-    name: "Test on Node.js ${{ matrix.node-version }}"
-    runs-on: ubuntu-latest
+    name: "Test on Node.js ${{ matrix.node-version }} OS: ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         node-version: [16, 18]
+        os: [ ubuntu-latest, windows-latest ]
+
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "build": "tsc -p .",
-    "clean": "rimraf lib/ module/",
+    "clean": "git clean -fx lib/ module/",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,css}\"",
     "prepare": "git config --local core.hooksPath .githooks",
     "prepublishOnly": "npm run clean && npm run build",
@@ -63,7 +63,6 @@
     "lint-staged": "^13.1.0",
     "mocha": "^10.2.0",
     "prettier": "^2.8.2",
-    "rimraf": "^4.0.4",
     "ts-node": "^10.9.1",
     "ts-node-test-register": "^10.0.0",
     "typescript": "^4.9.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,11 +238,6 @@ browser-stdout@1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-builtin-modules@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.3.0.tgz#cae62812b89801e9656336e46223e030386be7b6"
-  integrity sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==
-
 camelcase-keys@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-8.0.2.tgz#a7140ba7c797aea32161d4ce5cdbda11d09eb414"
@@ -1235,11 +1230,6 @@ rfdc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
-
-rimraf@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-4.0.4.tgz#8d0a91709fdc294d40f59c773f63c44e8dc878f1"
-  integrity sha512-R0hoVr9xTwemarQjoWlNt/nb5dEGVTBhVdkRmEX2zEkT8T6onH0XKiGjuaC7rNNj/gYzY2p4NVRJ3sjO1ascHQ==
 
 run-parallel@^1.1.9:
   version "1.2.0"


### PR DESCRIPTION
- `rm -rf`: no cross platform support 
- [`git clean -fx`](https://git-scm.com/docs/git-clean): cross platform support
- [`rimraf`](https://github.com/isaacs/rimraf): cross platform support, but need to install


fix #3 